### PR TITLE
Bot should also comment on issues with no replies

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -65,8 +65,6 @@ module Fastlane
 
     # Responsible for commenting to inactive issues, and closing them after a while
     def process_inactive(issue)
-      return if issue.comments == 0 # we haven't replied yet :(
-
       diff_in_months = (Time.now - issue.updated_at) / 60.0 / 60.0 / 24.0 / 30.0
 
       warning_sent = !!issue.labels.find { |a| a.name == AWAITING_REPLY }


### PR DESCRIPTION
We have a lot of unanswered issues where we didn’t reply yet. Initially the plan was to not auto-comment, since it’s kind of inpolite, however we don’t currently have the time resources to comment on those, so let the bot ping the author to see if the issue is still relevant