### PR TITLE
Also ping and close feature requests

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -23,7 +23,6 @@ module Fastlane
       
       client.issues(SLUG, per_page: 30, state: "all").each do |issue|
         next unless issue.pull_request.nil? # no PRs for now
-        next if issue.labels.collect { |a| a.name }.include?("feature") # we ignore all feature requests for now
 
         puts "Investigating issue ##{issue.number}..."
         process_open_issue(issue) if issue.state == "open"


### PR DESCRIPTION
Reasoning behind this: If there is a feature request, there should be active discussion around it, and maybe +1s to keep the issue alive. There are more than a hundred old issues with no activity at all that are tagged as feature. We should clean them up.

We'll be able to ping and close [136 open issues](https://github.com/fastlane/fastlane/issues?utf8=%E2%9C%93&q=label%3Afeature%20updated%3A%3C2016-06-30)