### PR TITLE
Support multiple PR refs per release note line

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -287,10 +287,18 @@ module Fastlane
     # release notes
     def collect_pr_references_from(release, prs_to_releases)
       release.body.split("\n").each do |item|
-        pr_number_match = item.match(/\(#(\d+)\)/)
+        # matches:
+        #   (#8324)
+        #   (#8324,#8325)
+        #   (#8324, #8325)
+        #   (#8324,#8325,#8326)
+        #   (#8324, #8325, #8326)
+        # etc.
+        pr_number_match = item.match(/\(#(\d+)(?:,\s?#(\d+))*\)/)
         if pr_number_match
-          pr_number = pr_number_match[1]
-          prs_to_releases[pr_number] = release.tag_name
+          pr_number_match.captures.each do |pr_number|
+            prs_to_releases[pr_number] = release.tag_name
+          end
         end
       end
     end


### PR DESCRIPTION
The formatting for one of the release notes lines in the most recent release was unexpected, and therefore the issue-bot did not handle it for posting PR congratulations.

> Improve design of user input questions (#8606, #8607) via Felix Krause

This improves the parsing of PR references from release notes to support multiple PR references per line, in the above format.