### PR TITLE
Reduce time until issue warning and auto close

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -8,8 +8,8 @@ require 'pry'
 module Fastlane
   class Bot
     SLUG = "fastlane/fastlane"
-    ISSUE_WARNING = 1.5 # in months
-    ISSUE_CLOSED = 0.3 # plus the x months from ISSUE_WARNING
+    ISSUE_WARNING = 1 # in months
+    ISSUE_CLOSED = 0.25 # plus the x months from ISSUE_WARNING
     ISSUE_LOCK = 2 # lock all issues with no activity within the last 3 months
     NEEDS_ATTENTION_PR_LIFESPAN_DAYS = 14 # threshold for marking a PR as needing attention
 


### PR DESCRIPTION
This reduces the time between the last activity and the bot warning to 1
month and the time between the warning and the auto close to about 1
week.

Feel free to edit the values if they're not exactly what we want.