### PR TITLE
Fix issue auto close not working anymore

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -335,11 +335,10 @@ module Fastlane
     end
 
     def last_responding_user(issue)
-      client.issue_comments(SLUG, issue.number)
+      first_page = client.issue_comments(SLUG, issue.number)
       link_to_last_page = client.last_response.rels[:last]
-      return unless link_to_last_page
-      last_comment_page = link_to_last_page.get.data
-      last_comment_page.last.user.login
+      last_page = link_to_last_page.get.data if link_to_last_page
+      return (last_page || first_page).last.user.login
     end
 
     def smart_sleep


### PR DESCRIPTION
Following this discussion: https://github.com/fastlane/issue-bot/pull/53#discussion_r158488110 I successfully reproduced the mentioned issue and confirmed that the proposed code snippet fixes it.

When there was only one comments page (in most cases), the `client.last_response.rels[:last]` was null, instead of the first/only page, so this checks for this case and returns the user from the first page.