### PR TITLE
Bot should not handle issues that have `status: has-pr` label

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -23,6 +23,7 @@ module Fastlane
     NEEDS_ATTENTION = 'status: needs-attention'
     RELEASED = 'status: released'
     INCLUDED_IN_NEXT_RELEASE = 'status: included-in-next-release'
+    HAS_PR = 'status: has-pr'
 
     ACTION_CHANNEL_SLACK_WEB_HOOK_URL = ENV['ACTION_CHANNEL_SLACK_WEB_HOOK_URL']
 

--- a/bot.rb
+++ b/bot.rb
@@ -100,6 +100,11 @@ module Fastlane
     end
 
     def process_open_issue(issue)
+      if has_label?(issue, HAS_PR)
+        logger.info("https://github.com/#{SLUG}/issues/#{issue.number} has PR 👍")
+        return
+      end
+      
       bot_actions = []
       process_inactive(issue)
 


### PR DESCRIPTION
### Description 

> @fastlane-bot unfortunately also tries to handle/close issues that have a PR waiting to be merged. It should look at the labels present, and not do anything for issues with label `status: has-pr`.

closes https://github.com/fastlane/fastlane/issues/14927

### How did you test the changes? 

Added `status: has-pr` label to the issue:

<img width="631" alt="Screen Shot 2019-07-05 at 09 22 32" src="https://user-images.githubusercontent.com/10795657/60705938-a64b0580-9f08-11e9-9c62-fb8a185d94d1.png">

I did run processing issue task `bundle exec rake process_issues`:

<img width="852" alt="Screen Shot 2019-07-05 at 09 21 56" src="https://user-images.githubusercontent.com/10795657/60706018-d7c3d100-9f08-11e9-9264-24fbc323a48b.png">

When this PR is merged and the new code is deployed to the server, the bot will no longer close the issues with `status: has-pr` label 👍 

Cheers 🤖