### PR TITLE
Bot should link to "contribution guides" in stale issues comment

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -302,6 +302,7 @@ module Fastlane
         body = []
         body << "There hasn't been any activity on this issue recently. Due to the high number of incoming GitHub notifications, we have to clean some of the old issues, as many of them have already been resolved with the latest updates."
         body << "Please make sure to update to the latest `fastlane` version and check if that solves the issue. Let us know if that works for you by adding a comment :+1:"
+        body << "Friendly reminder: contributions are always welcome! Check out [CONTRIBUTING.md](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md) for more information on how to help with `fastlane` and feel free to tackle this issue yourself :muscle:"
 
         client.add_comment(SLUG, issue.number, body.join("\n\n"))
         client.add_labels_to_an_issue(SLUG, issue.number, [AWAITING_REPLY])


### PR DESCRIPTION
### Description 

Nowadays, when a bot adds a comment to the stale issues, most of the time the issue is closed a few days after that by the bot. Adding link to "contribution guides" in the comment would suggest that the best way to get the issue done is by opening a PR. It might encourage new contributors to work on the project.

closes https://github.com/fastlane/fastlane/issues/14979

### How did you test the changes? 

I did run processing issue task `bundle exec rake process_issues` (a little bit modified condition when to add a comment about stale issue 🙂) on my private repository:

<img width="785" alt="Screen Shot 2019-07-06 at 14 37 41" src="https://user-images.githubusercontent.com/10795657/60756313-577e9800-9ffc-11e9-9515-2a6fb959211b.png">

Hopefully it will encourage even more people to make the contributions 🙌 

Cheers 🤖 