### PR TITLE
Bot should update linked issues when a PR is released

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -459,17 +459,16 @@ module Fastlane
       return new_text if new_text != text
     end
 
-    # Checks if a PR's description contains an issue reference.
+    # Checks if a PR's description contains an issue reference
     def referenced_issue_number?(pr)
       return unless pr.body
 
-      # Searching for `closes #1234` or `fixes #1234` in PR's description
+      # Searching for issue closing keywords + issue identifier in PR's description, i.e. `fixes #1234`
       issue_number = pr.body[/(#{ISSUE_CLOSING_KEYWORDS.join('|')}) #\d{1,}/i, 0]
       issue_number = issue_number[/#\d{1,}/i, 0] if issue_number
       issue_number = issue_number.tr('#', '') if issue_number
 
-      # Searching for `closes https://github.com/REPOSITORY_OWNER/REPOSITORY_NAME/issues/1234` 
-      # or `fixes https://github.com/fastlane/REPOSITORY_OWNER/REPOSITORY_NAME/1234 in PR's description
+      # Searching for issue closing keywords + issue URL in PR's description, i.e. `closes https://github.com/REPOSITORY_OWNER/REPOSITORY_NAME/issues/1234`
       issue_number = pr.body[/(#{ISSUE_CLOSING_KEYWORDS.join('|')}) https:\/\/github.com\/#{REPOSITORY_OWNER}\/#{REPOSITORY_NAME}\/issues\/\d{1,}/i, 0] unless issue_number
       issue_number = issue_number.split('/').last if issue_number
 

--- a/bot.rb
+++ b/bot.rb
@@ -459,7 +459,8 @@ module Fastlane
       return new_text if new_text != text
     end
 
-    # Checks if a PR's description contains an issue reference
+    # Checks if a PR's description contains an issue reference.
+    # This only works for issues in the same repository.
     def referenced_issue_number?(pr)
       return unless pr.body
 

--- a/bot.rb
+++ b/bot.rb
@@ -24,6 +24,19 @@ module Fastlane
     RELEASED = 'status: released'
     INCLUDED_IN_NEXT_RELEASE = 'status: included-in-next-release'
 
+    # Issue closing keywords: https://help.github.com/en/articles/closing-issues-using-keywords
+    ISSUE_CLOSING_KEYWORDS = [
+      "close",
+      "closes",
+      "closed",
+      "fix",
+      "fixes",
+      "fixed",
+      "resolve",
+      "resolves",
+      "resolved"
+    ]
+
     ACTION_CHANNEL_SLACK_WEB_HOOK_URL = ENV['ACTION_CHANNEL_SLACK_WEB_HOOK_URL']
 
     NEEDS_ATTENTION_PR_QUERY = "https://github.com/#{SLUG}/pulls?q=is%3Aopen+is%3Apr+label%3A%22#{NEEDS_ATTENTION}%22"
@@ -451,13 +464,13 @@ module Fastlane
       return unless pr.body
 
       # Searching for `closes #1234` or `fixes #1234` in PR's description
-      issue_number = pr.body[/(closes|fixes) #\d{1,}/i, 0]
+      issue_number = pr.body[/(#{ISSUE_CLOSING_KEYWORDS.join('|')}) #\d{1,}/i, 0]
       issue_number = issue_number[/#\d{1,}/i, 0] if issue_number
       issue_number = issue_number.tr('#', '') if issue_number
 
       # Searching for `closes https://github.com/REPOSITORY_OWNER/REPOSITORY_NAME/issues/1234` 
       # or `fixes https://github.com/fastlane/REPOSITORY_OWNER/REPOSITORY_NAME/1234 in PR's description
-      issue_number = pr.body[/(closes|fixes) https:\/\/github.com\/#{REPOSITORY_OWNER}\/#{REPOSITORY_NAME}\/issues\/\d{1,}/i, 0] unless issue_number
+      issue_number = pr.body[/(#{ISSUE_CLOSING_KEYWORDS.join('|')}) https:\/\/github.com\/#{REPOSITORY_OWNER}\/#{REPOSITORY_NAME}\/issues\/\d{1,}/i, 0] unless issue_number
       issue_number = issue_number.split('/').last if issue_number
 
       return issue_number


### PR DESCRIPTION
### Description 

> Currently @fastlane-bot already posts a comment to a PR thread when its changes are released. This could theoretically also be done in issue threads that are referenced in the PR description via closes #123 - then all the users that commented on the issue would also get a notification about the release and be motivated to try it.

closes https://github.com/fastlane/fastlane/issues/15001

### Implementation

I have been looking at [the documentation](http://octokit.github.io/octokit.rb/Octokit/Client/PullRequests.html) for an easier way to get the linked issue from a pr, but no luck. Had a look at [GitHub graphQL API](https://developer.github.com/v4/object/pullrequest/) - same, no luck. 

So I guess regex will do 💪 

### Testing

I prepared and tested several data sets:

```
input = nil
input = ''
input = "This is a PR description. fixes #123."
input = "This is a PR description. closes #123."
input = "This is a PR description. closes #corrupted_hash."
input = "This is a PR description. fixes #123. closes #321."
input = "This is a PR description. closes https://github.com/fastlane/fastlane/issues/1234."
input = "This is a PR description. fixes https://github.com/fastlane/fastlane/issues/1234."
input = "This is a PR description. fixes https://github.com/fastlane/fastlane/issues/1234. closes https://github.com/fastlane/fastlane/issues/1234."
input = "This is a PR description. closes https://github.com/another/project/issues/1234."
```

All good 👍 

```bash
$ bundle exec rake process_prs
```

```bash
...
I, [2019-07-12T18:41:22.759747 #99774]  INFO -- : Marking 4 as having been released in version 0.0.1
I, [2019-07-12T18:41:22.759805 #99774]  INFO -- : Adding a comment to the issue 1 that pull request 4 has been released
...
```

<img width="788" alt="Screen Shot 2019-07-12 at 18 36 26" src="https://user-images.githubusercontent.com/10795657/61144616-99fd1480-a4d5-11e9-8fbd-41ac04c66d46.png">

🙇 