### PR TITLE
Get rid of @fastlane-bot's comment about potential code signing issue

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -123,7 +123,6 @@ module Fastlane
       process_inactive(issue)
 
       return if issue.comments > 0 # there maybe already some bot replies
-      bot_actions << process_code_signing(issue)
       bot_actions << process_env_check(issue)
 
       new_body = fix_checkboxes(issue.body)
@@ -352,23 +351,6 @@ module Fastlane
         return body.join("\n\n")
       end
       return nil
-    end
-
-    # Ask people to check out the code signing bot
-    def process_code_signing(issue)
-      signing_words = ["signing", "provisioning"]
-      body = issue.body + issue.title
-      signing_related = signing_words.find_all do |keyword|
-        body.downcase.include?(keyword)
-      end
-      return nil if signing_related.count == 0
-
-      url = "https://docs.fastlane.tools/codesigning/getting-started/"
-      logger.info("https://github.com/#{SLUG}/issues/#{issue.number} (#{issue.title}) might have something to do with code signing")
-      body = []
-      body << "It seems like this issue might be related to code signing :no_entry_sign:"
-      body << "Have you seen our new [Code Signing Troubleshooting Guide](#{url})? It will help you resolve the most common code signing issues :+1:"
-      return body.join("\n\n")
     end
 
     def fetch_and_process_pinned_issues


### PR DESCRIPTION
## Description

> @fastlane-bot analyses an issue description and if it finds the words signing or provisioning, it will add the following comment (only if there are no comments at all): 

```
"It seems like this issue might be related to code signing :no_entry_sign:"
"Have you seen our new [Code Signing Troubleshooting Guide](#{url})? It will help you resolve the most common code signing issues :+1:"
```
closes https://github.com/fastlane/fastlane/issues/15226

## Implementation
Deleted `process_code_signing(issue)` method 💣 

## Testing

I tested the changes on my private project. When there is `provisioning` or `signing` keyword in the issue's description, the comment from bot about potential signing issue is not added anymore 🎉 

<img width="759" alt="Screen Shot 2019-08-26 at 19 02 29" src="https://user-images.githubusercontent.com/10795657/63708504-efe30d00-c834-11e9-9a46-4b3ff3949eb6.png">
